### PR TITLE
Harden GitHub Actions workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,32 +5,40 @@ on:
   schedule:
     - cron: "00 11 * * *" # once a day at 11:00 UTC / 6:00 EST
 
+permissions: {}
+
+concurrency:
+  group: update-content
+  cancel-in-progress: false
+
 jobs:
   build:
+    if: github.repository == 'PaloAltoNetworks/pan-chainguard-content'
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2 # checkout the repository content
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: setup python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x" # install the python version needed
 
       - name: install python packages
         run: |
           python -m pip install --upgrade pip
-          pip install aiohttp
-          pip install pan-python
-          pip install treelib
+          pip install -r requirements.txt
 
       - name: download pan-chainguard
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "PaloAltoNetworks/pan-chainguard"
           path: pan-chainguard
+          persist-credentials: false
 
       - name: Clean Up
         run: |
@@ -95,7 +103,9 @@ jobs:
           git diff-index --quiet HEAD || (git commit -a -m "updated files" --allow-empty)
 
       - name: push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
-        with:
-          branch: main
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git push origin main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp==3.13.5
+pan-python==0.25.0
+treelib==1.8.0


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` and concurrency group to serialize runs
- Set `persist-credentials: false` on all `actions/checkout` steps
- Update `actions/checkout` to v4 and `actions/setup-python` to v5
- Replace third-party `ad-m/github-push-action` with native `git push`
- Add repository ownership guard to prevent unintended fork execution
- Pin Python dependencies in `requirements.txt`
- Add Dependabot config for `github-actions` and `pip` ecosystems with 7-day cooldowns

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` and verify it completes successfully
- [ ] Confirm the push step works correctly with native `git push`
- [ ] Verify Dependabot begins creating PRs within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)